### PR TITLE
Fixed docstring in _build for the DNC module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -97,3 +97,6 @@ ENV/
 
 # mypy
 .mypy_cache/
+
+# PyCharm
+.idea

--- a/dnc.py
+++ b/dnc.py
@@ -87,7 +87,7 @@ class DNC(snt.RNNCore):
     Args:
       inputs: Tensor input.
       prev_state: A `DNCState` tuple containing the fields `access_output`,
-          `access_state` and `controller_state`. `access_state` is a 3-D Tensor
+          `access_state` and `controller_state`. `access_output` is a 3-D Tensor
           of shape `[batch_size, num_reads, word_size]` containing read words.
           `access_state` is a tuple of the access module's state, and
           `controller_state` is a tuple of controller module's state.

--- a/train.py
+++ b/train.py
@@ -141,6 +141,8 @@ def train(num_training_iterations, report_interval):
   with tf.train.SingularMonitoredSession(
       hooks=hooks, checkpoint_dir=FLAGS.checkpoint_dir) as sess:
 
+    writer = tf.summary.FileWriter("/tmp/log/...", sess.graph)
+
     start_iteration = sess.run(global_step)
     total_loss = 0
 
@@ -156,6 +158,8 @@ def train(num_training_iterations, report_interval):
                         train_iteration, total_loss / report_interval,
                         dataset_string)
         total_loss = 0
+
+    writer.close()
 
 
 def main(unused_argv):

--- a/train.py
+++ b/train.py
@@ -97,6 +97,8 @@ def train(num_training_iterations, report_interval):
   dataset = repeat_copy.RepeatCopy(FLAGS.num_bits, FLAGS.batch_size,
                                    FLAGS.min_length, FLAGS.max_length,
                                    FLAGS.min_repeats, FLAGS.max_repeats)
+
+  # Sonnet runs _build in RepeatCopy when you make a call to the module
   dataset_tensors = dataset()
 
   output_logits = run_model(dataset_tensors.observations, dataset.target_size)


### PR DESCRIPTION
1. 'access_state' should be 'access_output'.
2. Added PyCharm related files to .gitignore
3. Added a tf.summary.FileWriter to train.py so that the computation graph can be visualized in TensorBoard
4. Added a couple of short comments to train.py - might help those who are getting started with Sonnet
